### PR TITLE
Гибкая регистрация с возможностью выбора между упрощенным и полным сценарием

### DIFF
--- a/pro/user_app/urls.py
+++ b/pro/user_app/urls.py
@@ -2,11 +2,11 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('register/', views.PlayerRegisterViewSet.as_view(), name='register'),
-	path('login/', views.PlayerLoginViewSet.as_view(), name='login'),
- 	path('verify/', views.VerifyCodeViewSet.as_view(), name='verify'),
-	path('logout/', views.PlayerLogoutViewSet.as_view(), name='logout'),
-	path('player/', views.PlayerViewSet.as_view(), name='player'),
- 	path('password-reset/', views.PasswordResetRequestView.as_view(), name='password_reset_request'),
+    path('register/', views.FlexibleRegisterViewSet.as_view(), name='register'),
+    path('login/', views.PlayerLoginViewSet.as_view(), name='login'),
+    path('verify/', views.VerifyCodeViewSet.as_view(), name='verify'),
+    path('logout/', views.PlayerLogoutViewSet.as_view(), name='logout'),
+    path('player/', views.PlayerViewSet.as_view(), name='player'),
+    path('password-reset/', views.PasswordResetRequestView.as_view(), name='password_reset_request'),
     path('password-reset-confirm/', views.PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
 ]


### PR DESCRIPTION
Теперь регистрация работает так:

1. Выбор сценария: При регистрации пользователь может выбрать между двумя вариантами:
   - Упрощенная регистрация (только логин и пароль).
   - Полная регистрация (логин, пароль, email и телефон).

2. Упрощенная регистрация:
   - Пользователь вводит логин и пароль, и если он выбирает этот вариант, то сразу получает доступ (JWT токены) без необходимости подтверждать свою почту.
   - Всё просто и быстро: ввел данные, получил доступ.

3. Полная регистрация:
   - Пользователь вводит логин, пароль, email и телефон.
   - Ему отправляется код на почту, который он должен ввести для активации аккаунта.
   - Только после этого он получит свои JWT токены для входа.

Таким образом, пользователи могут сами решать, что им удобнее: быстрая регистрация без почты или полная регистрация с верификацией.

Ребята, нашел такой выход из ситуации с регистрацией: мы добавляем в нашу форму регистрации чекбокс "Регистрация без email и телефона". Если пользователь его отметит, то ему нужно будет указать только логин и пароль, а поля для email и телефона станут необязательными и скроются. При этом, как только пользователь зарегистрируется, он сразу получит свои JWT токены для доступа к системе, без всякой дополнительной верификации через код по почте.

Это позволит нам быстро регистрировать пользователей, которым не нужны лишние заморочки с почтой и телефонами. А те, кому нужна полная регистрация с проверкой email, могут просто оставить этот чекбокс неотмеченным и пройти стандартный процесс с отправкой кода. В итоге, мы дадим нашим пользователям возможность выбрать, как они хотят зарегистрироваться, что упростит их взаимодействие с нашим сервисом.

![output (1)](https://github.com/user-attachments/assets/426c0716-3d0a-4ed2-827d-833f2d6593c2)
